### PR TITLE
setup.cfg: remove quotes from url

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 author = simon
 author_email = simonm3@gmail.com
-url =  'https://github.com/simonm3/mim'
+url =  https://github.com/simonm3/mim
 classifiers = Development Status :: 4 - Beta
     Environment :: Console
     License :: OSI Approved :: GNU General Public License (GPL)


### PR DESCRIPTION
They mess up the homepage link on PyPI.
